### PR TITLE
Fixed help strings in preprocess.py

### DIFF
--- a/tensorflow_tts/bin/preprocess.py
+++ b/tensorflow_tts/bin/preprocess.py
@@ -96,14 +96,14 @@ def main():
         type=int,
         default=4,
         required=False,
-        help="yaml format configuration file.",
+        help="number of CPUs to use for multi-processing.",
     )
     parser.add_argument(
         "--test_size",
         type=float,
         default=0.05,
         required=False,
-        help="yaml format configuration file.",
+        help="the proportion of the dataset to include in the test split. (default=0.05)",
     )
     parser.add_argument(
         "--verbose",


### PR DESCRIPTION
Fixed the help strings in the argument parser of preprocess.py, it seems that the previous help strings were copied from the yaml config argument.