### PR TITLE
fix multi-band melgan order

### DIFF
--- a/tensorflow_tts/inference/auto_model.py
+++ b/tensorflow_tts/inference/auto_model.py
@@ -39,8 +39,8 @@ TF_MODEL_MAPPING = OrderedDict(
     [
         (FastSpeechConfig, TFFastSpeech),
         (FastSpeech2Config, TFFastSpeech2),
-        (MelGANGeneratorConfig, TFMelGANGenerator),
         (MultiBandMelGANGeneratorConfig, TFMBMelGANGenerator),
+        (MelGANGeneratorConfig, TFMelGANGenerator),
         (Tacotron2Config, TFTacotron2)
     ]
 )


### PR DESCRIPTION
If the order of multi-ban MelGan is after normal MelGan, 
the following code will choose MelGan instead of Multi-Band MelGan:
```
            if isinstance(config, config_class) and str(config_class.__name__) in str(config):
```