### PR TITLE
Python staticmethods cannot refer to self

### DIFF
--- a/tensorflow_tts/processor/libritts.py
+++ b/tensorflow_tts/processor/libritts.py
@@ -94,8 +94,7 @@ class LibriTTSProcessor(BaseProcessor):
         else:
             return self.inference_text_to_seq(text)
 
-    @staticmethod
-    def inference_text_to_seq(text: str):
+    def inference_text_to_seq(self, text: str):
         return self.symbols_to_ids(self.text_to_ph(text))
 
     def symbols_to_ids(self, symbols_list: list):


### PR DESCRIPTION
https://docs.python.org/3/library/functions.html#staticmethod