### PR TITLE
👙 Optimize embedding layer

### DIFF
--- a/tensorflow_tts/models/fastspeech.py
+++ b/tensorflow_tts/models/fastspeech.py
@@ -63,15 +63,10 @@ ACT2FN = {
 }
 
 
-class TFEmbedding(tf.keras.layers.Layer):
+class TFEmbedding(tf.keras.layers.Embedding):
     """Faster version of embedding."""
-    def __init__(self, vocab_size, dim, embeddings_initializer, **kwargs):
-        super().__init__(**kwargs)
-        self.embeddings = self.add_weight(
-            "embeddings",
-            shape=[vocab_size, dim],
-            initializer=embeddings_initializer,
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def call(self, inputs):
         inputs = tf.cast(tf.expand_dims(inputs, -1), tf.int32)

--- a/tensorflow_tts/models/fastspeech2.py
+++ b/tensorflow_tts/models/fastspeech2.py
@@ -48,7 +48,7 @@ class TFFastSpeechVariantPredictor(tf.keras.layers.Layer):
         self.output_layer = tf.keras.layers.Dense(1)
 
         if config.n_speakers > 1:
-            self.decoder_speaker_embeddings = TFEmbedding(
+            self.decoder_speaker_embeddings = tf.keras.layers.Embedding(
                 config.n_speakers,
                 config.encoder_self_attention_params.hidden_size,
                 embeddings_initializer=get_initializer(config.initializer_range),

--- a/tensorflow_tts/models/fastspeech2.py
+++ b/tensorflow_tts/models/fastspeech2.py
@@ -48,7 +48,7 @@ class TFFastSpeechVariantPredictor(tf.keras.layers.Layer):
         self.output_layer = tf.keras.layers.Dense(1)
 
         if config.n_speakers > 1:
-            self.decoder_speaker_embeddings = tf.keras.layers.Embedding(
+            self.decoder_speaker_embeddings = TFEmbedding(
                 config.n_speakers,
                 config.encoder_self_attention_params.hidden_size,
                 embeddings_initializer=get_initializer(config.initializer_range),

--- a/tensorflow_tts/models/tacotron2.py
+++ b/tensorflow_tts/models/tacotron2.py
@@ -70,15 +70,10 @@ ACT2FN = {
 }
 
 
-class TFEmbedding(tf.keras.layers.Layer):
+class TFEmbedding(tf.keras.layers.Embedding):
     """Faster version of embedding."""
-    def __init__(self, vocab_size, dim, embeddings_initializer, **kwargs):
-        super().__init__(**kwargs)
-        self.embeddings = self.add_weight(
-            "embeddings",
-            shape=[vocab_size, dim],
-            initializer=embeddings_initializer,
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def call(self, inputs):
         inputs = tf.cast(tf.expand_dims(inputs, -1), tf.int32)


### PR DESCRIPTION
This is a PR include small changes to optimize training speed, bellow is my observation of tacotron-2's training speed:

TF 2.2.0 (4s/1it) -> TF 2.3.0 (3.5s/1it) -> TF 2.3.0 + Faster Embedding (3.0s/1it). All brenchmarks run on 2080Ti with batch_size 32, non mixed_precision.

Related issue: https://github.com/tensorflow/tensorflow/issues/38287