### PR TITLE
Add finetuning (--pretrained) option to training scripts 

### DIFF
--- a/examples/fastspeech/README.md
+++ b/examples/fastspeech/README.md
@@ -29,6 +29,11 @@ In case you want to resume the training progress, please following below example
 --resume ./examples/fastspeech/exp/train.fastspeech.v1/checkpoints/ckpt-100000
 ```
 
+If you want to finetune a model, use `--pretrained` like this with your model filename
+```bash
+--pretrained pretrained.h5
+```
+
 ### Step 3: Decode mel-spectrogram from folder ids
 To running inference on folder ids (charactor), run below command line:
 

--- a/examples/fastspeech/train_fastspeech.py
+++ b/examples/fastspeech/train_fastspeech.py
@@ -333,8 +333,9 @@ def main():
         fastspeech.summary()
         
         if len(args.pretrained) > 1:
-            print("Loading pretrained parameters...")
-            fastspeech.load_weights(args.pretrained,by_name=True,skip_mismatch=True)
+            fastspeech.load_weights(args.pretrained, by_name=True, skip_mismatch=True)
+            logging.info(f"Successfully loaded pretrained weight from {args.pretrained}.")
+
 
         # AdamW for fastspeech
         learning_rate_fn = tf.keras.optimizers.schedules.PolynomialDecay(

--- a/examples/fastspeech/train_fastspeech.py
+++ b/examples/fastspeech/train_fastspeech.py
@@ -209,6 +209,13 @@ def main():
         type=int,
         help="using mixed precision for generator or not.",
     )
+    parser.add_argument(
+        "--pretrained",
+        default="",
+        type=str,
+        nargs="?",
+        help='pretrained checkpoint file to load weights from. Auto-skips non-matching layers',
+    )
     args = parser.parse_args()
 
     # return strategy
@@ -324,6 +331,10 @@ def main():
         )
         fastspeech._build()
         fastspeech.summary()
+        
+        if len(args.pretrained) > 1:
+            print("Loading pretrained parameters...")
+            fastspeech.load_weights(args.pretrained,by_name=True,skip_mismatch=True)
 
         # AdamW for fastspeech
         learning_rate_fn = tf.keras.optimizers.schedules.PolynomialDecay(

--- a/examples/fastspeech2/README.md
+++ b/examples/fastspeech2/README.md
@@ -31,6 +31,12 @@ In case you want to resume the training progress, please following below example
 --resume ./examples/fastspeech2/exp/train.fastspeech2.v1/checkpoints/ckpt-100000
 ```
 
+If you want to finetune a model, use `--pretrained` like this with your model filename
+```bash
+--pretrained pretrained.h5
+```
+
+
 ### Step 3: Decode mel-spectrogram from folder ids
 
 ```bash

--- a/examples/fastspeech2/train_fastspeech2.py
+++ b/examples/fastspeech2/train_fastspeech2.py
@@ -362,8 +362,9 @@ def main():
         fastspeech._build()
         fastspeech.summary()
         if len(args.pretrained) > 1:
-            print("Loading pretrained parameters...")
-            fastspeech.load_weights(args.pretrained,by_name=True,skip_mismatch=True)
+            fastspeech.load_weights(args.pretrained, by_name=True, skip_mismatch=True)
+            logging.info(f"Successfully loaded pretrained weight from {args.pretrained}.")
+
 
         # AdamW for fastspeech
         learning_rate_fn = tf.keras.optimizers.schedules.PolynomialDecay(

--- a/examples/fastspeech2/train_fastspeech2.py
+++ b/examples/fastspeech2/train_fastspeech2.py
@@ -235,6 +235,15 @@ def main():
         type=int,
         help="using mixed precision for generator or not.",
     )
+    parser.add_argument(
+        "--pretrained",
+        default="",
+        type=str,
+        nargs="?",
+        help='pretrained weights .h5 file to load weights from. Auto-skips non-matching layers',
+    )
+    
+
     args = parser.parse_args()
 
     # return strategy
@@ -352,6 +361,9 @@ def main():
         )
         fastspeech._build()
         fastspeech.summary()
+        if len(args.pretrained) > 1:
+            print("Loading pretrained parameters...")
+            fastspeech.load_weights(args.pretrained,by_name=True,skip_mismatch=True)
 
         # AdamW for fastspeech
         learning_rate_fn = tf.keras.optimizers.schedules.PolynomialDecay(

--- a/examples/fastspeech2_libritts/train_fastspeech2.py
+++ b/examples/fastspeech2_libritts/train_fastspeech2.py
@@ -396,8 +396,9 @@ def main():
         fastspeech.summary()
         
         if len(args.pretrained) > 1:
-            print("Loading pretrained parameters...")
-            fastspeech.load_weights(args.pretrained,by_name=True,skip_mismatch=True)
+            fastspeech.load_weights(args.pretrained, by_name=True, skip_mismatch=True)
+            logging.info(f"Successfully loaded pretrained weight from {args.pretrained}.")
+
 
         # AdamW for fastspeech
         learning_rate_fn = tf.keras.optimizers.schedules.PolynomialDecay(

--- a/examples/fastspeech2_libritts/train_fastspeech2.py
+++ b/examples/fastspeech2_libritts/train_fastspeech2.py
@@ -268,6 +268,13 @@ def main():
         default="dump/stats.npy",
         type=str,
     )
+    parser.add_argument(
+        "--pretrained",
+        default="",
+        type=str,
+        nargs="?",
+        help='pretrained weights .h5 file to load weights from. Auto-skips non-matching layers',
+    )
     args = parser.parse_args()
 
     # return strategy
@@ -387,6 +394,10 @@ def main():
         )
         fastspeech._build()
         fastspeech.summary()
+        
+        if len(args.pretrained) > 1:
+            print("Loading pretrained parameters...")
+            fastspeech.load_weights(args.pretrained,by_name=True,skip_mismatch=True)
 
         # AdamW for fastspeech
         learning_rate_fn = tf.keras.optimizers.schedules.PolynomialDecay(

--- a/examples/melgan.stft/README.md
+++ b/examples/melgan.stft/README.md
@@ -43,6 +43,11 @@ In case you want to resume the training progress, please following below example
 --resume ./examples/melgan.stft/exp/train.melgan.stft.v1/checkpoints/ckpt-100000
 ```
 
+If you want to finetune a model, use `--pretrained` like this with the filename of the generator
+```bash
+--pretrained ptgenerator.h5
+```
+
 **IMPORTANT NOTES**:
 
 - When training generator only, we enable mixed precision to speed-up training progress.

--- a/examples/melgan.stft/train_melgan_stft.py
+++ b/examples/melgan.stft/train_melgan_stft.py
@@ -201,6 +201,13 @@ def main():
         type=int,
         help="using mixed precision for discriminator or not.",
     )
+    parser.add_argument(
+        "--pretrained",
+        default="",
+        type=str,
+        nargs="?",
+        help='path of .h5 melgan generator to load weights from',
+    )
     args = parser.parse_args()
 
     # return strategy
@@ -337,6 +344,10 @@ def main():
         fake_mels = tf.random.uniform(shape=[1, 100, 80], dtype=tf.float32)
         y_hat = generator(fake_mels)
         discriminator(y_hat)
+        
+        if len(args.pretrained) > 1:
+            print("Loading pretrained weights...")
+            generator.load_weights(args.pretrained)
 
         generator.summary()
         discriminator.summary()

--- a/examples/melgan.stft/train_melgan_stft.py
+++ b/examples/melgan.stft/train_melgan_stft.py
@@ -346,8 +346,9 @@ def main():
         discriminator(y_hat)
         
         if len(args.pretrained) > 1:
-            print("Loading pretrained weights...")
             generator.load_weights(args.pretrained)
+            logging.info(f"Successfully loaded pretrained weight from {args.pretrained}.")
+
 
         generator.summary()
         discriminator.summary()

--- a/examples/melgan/README.md
+++ b/examples/melgan/README.md
@@ -29,6 +29,12 @@ In case you want to resume the training progress, please following below example
 --resume ./examples/melgan/exp/train.melgan.v1/checkpoints/ckpt-100000
 ```
 
+If you want to finetune a model, use `--pretrained` like this with the filename of the generator
+```bash
+--pretrained ptgenerator.h5
+```
+
+
 ### Step 3: Decode audio from folder mel-spectrogram
 To running inference on folder mel-spectrogram (eg tacotron2.v1), run below command line:
 

--- a/examples/melgan/train_melgan.py
+++ b/examples/melgan/train_melgan.py
@@ -479,8 +479,9 @@ def main():
         discriminator(y_hat)
         
         if len(args.pretrained) > 1:
-            print("Loading pretrained weights...")
             generator.load_weights(args.pretrained)
+            logging.info(f"Successfully loaded pretrained weight from {args.pretrained}.")
+
 
 
         generator.summary()

--- a/examples/melgan/train_melgan.py
+++ b/examples/melgan/train_melgan.py
@@ -334,6 +334,13 @@ def main():
         type=int,
         help="using mixed precision for discriminator or not.",
     )
+    parser.add_argument(
+        "--pretrained",
+        default="",
+        type=str,
+        nargs="?",
+        help='path of .h5 melgan generator to load weights from',
+    )
     args = parser.parse_args()
 
     # return strategy
@@ -470,6 +477,11 @@ def main():
         fake_mels = tf.random.uniform(shape=[1, 100, 80], dtype=tf.float32)
         y_hat = generator(fake_mels)
         discriminator(y_hat)
+        
+        if len(args.pretrained) > 1:
+            print("Loading pretrained weights...")
+            generator.load_weights(args.pretrained)
+
 
         generator.summary()
         discriminator.summary()

--- a/examples/multiband_melgan/README.md
+++ b/examples/multiband_melgan/README.md
@@ -43,6 +43,11 @@ In case you want to resume the training progress, please following below example
 --resume ./examples/multiband_melgan/exp/train.multiband_melgan.v1/checkpoints/ckpt-100000
 ```
 
+If you want to finetune a model, use `--pretrained` like this with the filename of the generator
+```bash
+--pretrained ptgenerator.h5
+```
+
 **IMPORTANT NOTES**:
 
 - If Your Dataset is 16K, upsample_scales = [2, 4, 8] worked.

--- a/examples/multiband_melgan/train_multiband_melgan.py
+++ b/examples/multiband_melgan/train_multiband_melgan.py
@@ -454,8 +454,8 @@ def main():
         discriminator(y_hat)
         
         if len(args.pretrained) > 1:
-            print("Loading pretrained weights...")
             generator.load_weights(args.pretrained)
+            logging.info(f"Successfully loaded pretrained weight from {args.pretrained}.")
 
         generator.summary()
         discriminator.summary()

--- a/examples/multiband_melgan/train_multiband_melgan.py
+++ b/examples/multiband_melgan/train_multiband_melgan.py
@@ -304,6 +304,13 @@ def main():
         type=int,
         help="using mixed precision for discriminator or not.",
     )
+    parser.add_argument(
+        "--pretrained",
+        default="",
+        type=str,
+        nargs="?",
+        help='path of .h5 mb-melgan generator to load weights from',
+    )
     args = parser.parse_args()
 
     # return strategy
@@ -445,6 +452,10 @@ def main():
         y_mb_hat = generator(fake_mels)
         y_hat = pqmf.synthesis(y_mb_hat)
         discriminator(y_hat)
+        
+        if len(args.pretrained) > 1:
+            print("Loading pretrained weights...")
+            generator.load_weights(args.pretrained)
 
         generator.summary()
         discriminator.summary()

--- a/examples/multiband_pwgan/train_multiband_pwgan.py
+++ b/examples/multiband_pwgan/train_multiband_pwgan.py
@@ -469,9 +469,9 @@ def main():
         y_hat = pqmf.synthesis(y_mb_hat)
         discriminator(y_hat)
         
-        if len(args.pretrained) > 2:
-          print("Loading pretrained weights...")
-          generator.load_weights(args.pretrained)
+        if len(args.pretrained) > 1:
+            print("Loading pretrained weights...")
+            generator.load_weights(args.pretrained)
 
         generator.summary()
         discriminator.summary()

--- a/examples/multiband_pwgan/train_multiband_pwgan.py
+++ b/examples/multiband_pwgan/train_multiband_pwgan.py
@@ -470,8 +470,9 @@ def main():
         discriminator(y_hat)
         
         if len(args.pretrained) > 1:
-            print("Loading pretrained weights...")
             generator.load_weights(args.pretrained)
+            logging.info(f"Successfully loaded pretrained weight from {args.pretrained}.")
+
 
         generator.summary()
         discriminator.summary()

--- a/examples/tacotron2/README.md
+++ b/examples/tacotron2/README.md
@@ -29,6 +29,11 @@ In case you want to resume the training progress, please following below example
 --resume ./examples/tacotron2/exp/train.tacotron2.v1/checkpoints/ckpt-100000
 ```
 
+If you want to finetune a model, use `--pretrained` like this with your model filename
+```bash
+--pretrained pretrained.h5
+```
+
 ### Step 3: Decode mel-spectrogram from folder ids
 To running inference on folder ids (charactor), run below command line:
 

--- a/examples/tacotron2/train_tacotron2.py
+++ b/examples/tacotron2/train_tacotron2.py
@@ -434,8 +434,9 @@ def main():
         tacotron2.summary()
         
         if len(args.pretrained) > 1:
-            print("Loading pretrained parameters...")
-            tacotron2.load_weights(args.pretrained,by_name=True,skip_mismatch=True)
+            tacotron2.load_weights(args.pretrained, by_name=True, skip_mismatch=True)
+            logging.info(f"Successfully loaded pretrained weight from {args.pretrained}.")
+
 
 
 

--- a/examples/tacotron2/train_tacotron2.py
+++ b/examples/tacotron2/train_tacotron2.py
@@ -304,6 +304,13 @@ def main():
         type=int,
         help="using mixed precision for generator or not.",
     )
+    parser.add_argument(
+        "--pretrained",
+        default="",
+        type=str,
+        nargs="?",
+        help='pretrained weights .h5 file to load weights from. Auto-skips non-matching layers',
+    )
     args = parser.parse_args()
 
     # return strategy
@@ -425,6 +432,12 @@ def main():
         tacotron2 = TFTacotron2(config=tacotron_config, training=True, name="tacotron2")
         tacotron2._build()
         tacotron2.summary()
+        
+        if len(args.pretrained) > 1:
+            print("Loading pretrained parameters...")
+            tacotron2.load_weights(args.pretrained,by_name=True,skip_mismatch=True)
+
+
 
         # AdamW for tacotron2
         learning_rate_fn = tf.keras.optimizers.schedules.PolynomialDecay(


### PR DESCRIPTION
Simple finetuning oriented options to load pretrained weights to make people like https://github.com/TensorSpeech/TensorFlowTTS/issues/213 and  https://github.com/TensorSpeech/TensorFlowTTS/issues/229 not have to implement finetuning themselves. In the text2mel models, the load weights functions have `by_name=True,skip_mismatch=True` arguments.
In the vocoders, only generator is loaded, although I can change that