### PR TITLE
Replaced hardcoded path separator for multiple OS support

### DIFF
--- a/examples/fastspeech2_libritts/libri_experiment/prepare_libri.ipynb
+++ b/examples/fastspeech2_libritts/libri_experiment/prepare_libri.ipynb
@@ -117,7 +117,7 @@
     "for sp_id, v in poss_speakers.items():\n",
     "    if sp_id in to_move:\n",
     "        for j in v:\n",
-    "            f_name = j.split(\"/\")[-1]\n",
+    "            f_name = j.split(os.path.sep)[-1]\n",
     "            text_f_name = f_name.split(\".wav\")[0] + \".txt\"\n",
     "            os.makedirs(os.path.join(dataset_path, sp_id), exist_ok=True)\n",
     "            shutil.copy(j, os.path.join(dataset_path, sp_id, f_name))\n",


### PR DESCRIPTION
I tried running this notebook on my Windows machine and it didn't work. 

Replacing the hardcoded UNIX path separator with `os.path.sep` makes this support different OSes.