### PR TITLE
Updated run_mfa.py script to work in Windows

### DIFF
--- a/examples/mfa_extraction/run_mfa.py
+++ b/examples/mfa_extraction/run_mfa.py
@@ -18,14 +18,15 @@ from subprocess import call
 from pathlib import Path
 
 import click
+import os
 
 
 @click.command()
-@click.option("--mfa_path", default="mfa/montreal-forced-aligner/bin/mfa_align")
+@click.option("--mfa_path", default=os.path.join('mfa', 'montreal-forced-aligner', 'bin', 'mfa_align'))
 @click.option("--corpus_directory", default="libritts")
-@click.option("--lexicon", default="mfa/lexicon/librispeech-lexicon.txt")
-@click.option("--acoustic_model_path", default="mfa/montreal-forced-aligner/pretrained_models/english.zip")
-@click.option("--output_directory", default="mfa/parsed")
+@click.option("--lexicon", default=os.path.join('mfa', 'lexicon', 'librispeech-lexicon.txt'))
+@click.option("--acoustic_model_path", default=os.path.join('mfa', 'montreal-forced-aligner', 'pretrained_models', 'english.zip'))
+@click.option("--output_directory", default=os.path.join('mfa', 'parsed'))
 @click.option("--jobs", default="8")
 def run_mfa(
     mfa_path: str,
@@ -38,7 +39,7 @@ def run_mfa(
     Path(output_directory).mkdir(parents=True, exist_ok=True)
     call(
         [
-            f"./{mfa_path}",
+            f".{os.path.sep}{mfa_path}",
             corpus_directory,
             lexicon,
             acoustic_model_path,


### PR DESCRIPTION
Removes OS-specific separators and uses `os.path` instead.