### PR TITLE
Fixed typo in MB-Melgan config

### DIFF
--- a/examples/multiband_melgan/conf/multiband_melgan.v1.yaml
+++ b/examples/multiband_melgan/conf/multiband_melgan.v1.yaml
@@ -69,7 +69,7 @@ lambda_adv: 2.5              # Loss balancing coefficient for adversarial loss.
 ###########################################################
 batch_size: 64                 # Batch size.
 batch_max_steps: 8192          # Length of each audio in batch for training. Make sure dividable by hop_size.
-batch_max_steps_valid: 81920   # Length of each audio for validation. Make sure dividable by hope_size.
+batch_max_steps_valid: 8192    # Length of each audio for validation. Make sure dividable by hope_size.
 remove_short_samples: true     # Whether to remove samples the length of which are less than batch_max_steps.
 allow_cache: true              # Whether to allow cache in dataset. If true, it requires cpu memory.
 is_shuffle: true               # shuffle dataset after each epoch.


### PR DESCRIPTION
Solves the OOM error when using the example MB-Melgan config in https://github.com/TensorSpeech/TensorFlowTTS/issues/354.