### PR TITLE
Support for German Umlaute ÖÄÜöäü and ß. Ignore unnecessary warnings during preprocessing (>= -> >)

### DIFF
--- a/tensorflow_tts/bin/preprocess.py
+++ b/tensorflow_tts/bin/preprocess.py
@@ -194,7 +194,7 @@ def gen_audio_features(item, config):
     # check audio properties
     assert len(audio.shape) == 1, f"{utt_id} seems to be multi-channel signal."
     assert np.abs(audio).max() <= 1.0, f"{utt_id} is different from 16 bit PCM."
-    
+
     # check sample rate
     if rate != config["sampling_rate"]:
         audio = librosa.resample(audio, rate, config["sampling_rate"])
@@ -290,7 +290,7 @@ def gen_audio_features(item, config):
     # apply global gain
     if config["global_gain_scale"] > 0.0:
         audio *= config["global_gain_scale"]
-    if np.abs(audio).max() >= 1.0:
+    if np.abs(audio).max() > 1.0:
         logging.warn(
             f"{utt_id} causes clipping. It is better to reconsider global gain scale value."
         )
@@ -355,7 +355,7 @@ def preprocess():
         "libritts": LibriTTSProcessor,
         "baker": BakerProcessor,
         "thorsten": ThorstenProcessor,
-        "ljspeechu" : LJSpeechUltimateProcessor,
+        "ljspeechu": LJSpeechUltimateProcessor,
         "synpaflex": SynpaflexProcessor,
     }
 
@@ -387,7 +387,7 @@ def preprocess():
     )
 
     # check output directories
-    build_dir = lambda x: [
+    def build_dir(x): return [
         os.makedirs(os.path.join(config["outdir"], x, y), exist_ok=True)
         for y in ["raw-feats", "wavs", "ids", "raw-f0", "raw-energies"]
     ]
@@ -421,7 +421,7 @@ def preprocess():
     logging.info(f"Training items: {len(train_split)}")
     logging.info(f"Validation items: {len(valid_split)}")
 
-    get_utt_id = lambda x: os.path.split(x[1])[-1].split(".")[0]
+    def get_utt_id(x): return os.path.split(x[1])[-1].split(".")[0]
     train_utt_ids = [get_utt_id(x) for x in train_split]
     valid_utt_ids = [get_utt_id(x) for x in valid_split]
 
@@ -548,7 +548,7 @@ def compute_statistics():
     config = parse_and_config()
 
     # find features files for the train split
-    glob_fn = lambda x: glob.glob(os.path.join(config["rootdir"], "train", x, "*.npy"))
+    def glob_fn(x): return glob.glob(os.path.join(config["rootdir"], "train", x, "*.npy"))
     glob_mel = glob_fn("raw-feats")
     glob_f0 = glob_fn("raw-f0")
     glob_energy = glob_fn("raw-energies")

--- a/tensorflow_tts/configs/tacotron2.py
+++ b/tensorflow_tts/configs/tacotron2.py
@@ -22,6 +22,7 @@ from tensorflow_tts.processor.baker import BAKER_SYMBOLS as bk_symbols
 from tensorflow_tts.processor.libritts import LIBRITTS_SYMBOLS as lbri_symbols
 from tensorflow_tts.processor.ljspeechu import LJSPEECH_U_SYMBOLS as lju_symbols
 from tensorflow_tts.processor.synpaflex import SYNPAFLEX_SYMBOLS as synpaflex_symbols
+from tensorflow_tts.processor.thorsten import THORSTEN_SYMBOLS as thorsten_symbols
 
 
 class Tacotron2Config(BaseConfig):
@@ -72,6 +73,8 @@ class Tacotron2Config(BaseConfig):
             self.vocab_size = len(lju_symbols)
         elif dataset == "synpaflex":
             self.vocab_size = len(synpaflex_symbols)
+        elif dataset == "thorsten":
+            self.vocab_size = len(thorsten_symbols)
         else:
             raise ValueError("No such dataset: {}".format(dataset))
         self.embedding_hidden_size = embedding_hidden_size

--- a/tensorflow_tts/processor/base_processor.py
+++ b/tensorflow_tts/processor/base_processor.py
@@ -116,7 +116,7 @@ class BaseProcessor(abc.ABC):
                 wav_path = os.path.join(self.data_dir, parts[self.positions["file"]])
                 wav_path = (
                     wav_path + self.f_extension
-                    if wav_path[-len(self.f_extension) :] != self.f_extension
+                    if wav_path[-len(self.f_extension):] != self.f_extension
                     else wav_path
                 )
                 text = parts[self.positions["text"]]
@@ -223,7 +223,7 @@ class BaseProcessor(abc.ABC):
             }
             if extra_attrs_to_save:
                 full_mapper = {**full_mapper, **extra_attrs_to_save}
-            json.dump(full_mapper, f)
+            json.dump(full_mapper, f, ensure_ascii=False)
 
     @abc.abstractmethod
     def save_pretrained(self, saved_path):

--- a/tensorflow_tts/processor/thorsten.py
+++ b/tensorflow_tts/processor/thorsten.py
@@ -28,7 +28,7 @@ _pad = "pad"
 _eos = "eos"
 _punctuation = "!'(),.? "
 _special = "-"
-_letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+_letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜabcdefghijklmnopqrstuvwxyzäöüß"
 
 # Export all symbols:
 THORSTEN_SYMBOLS = (


### PR DESCRIPTION
In the current implementation, German letters ÖÄÜöäü and ß are not supported. I changed this in this commit, and added support for Tacotron2 training with the correct German alphabet.

Note that without these letters the text-to-speech model cannot pronounce many German words correctly. This will, however, also affect backwards compatibility for models trained on the "old" wrong German alphabet. 

I also adjusted a warning condition in the preprocessing script, which raised unjustified warnings due to a greater-equal instead of a just greater condition.